### PR TITLE
make sure package name is `openlabs` in releases

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -26,6 +26,7 @@ builds:
 
 nfpms:
   - maintainer: "https://github.com/OpenLabsHQ"
+    package_name: openlabs
     formats:
       - deb
       - rpm
@@ -34,7 +35,7 @@ nfpms:
 archives:
   - format: tar.gz
     name_template: >-
-      {{ .ProjectName }}_
+      openlabs_
       {{- .Version }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64


### PR DESCRIPTION
- Goreleaser would previously install package `cli`. 
- Now, package is installed as `openlabs` so users can `apt install openlabs`, etc.