### PR TITLE
remove -next suffix from openlabs version

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -54,7 +54,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  name_template: "{{ incpatch .Version }}"
 
 release:
   draft: false


### PR DESCRIPTION
This will make the version in the cli match the tag on github:

Before:
![image](https://github.com/user-attachments/assets/29bfc562-0dca-4838-a0ac-bde8be38c0e6)

After:
![image](https://github.com/user-attachments/assets/e7a6ecc2-cde8-4213-81a4-8090c7d91911)
