### PR TITLE
Allow documentation changes from auto in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
   prepare:
     name: Prepare Release
     needs: [check_pr_labels]
-    if: ${{ needs.check_pr_labels.outputs.skip_build != 'true' || github.event_name != 'workflow_run' }}
+    if: ${{ github.event_name != 'workflow_run' || needs.check_pr_labels.outputs.skip_build != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.get_tag.outputs.tag_name }}
@@ -80,7 +80,7 @@ jobs:
   release:
     name: Create Release
     needs: [check_pr_labels, prepare]
-    if: ${{ needs.check_pr_labels.outputs.skip_build != 'true' || github.event_name != 'workflow_run' }}
+    if: ${{ github.event_name != 'workflow_run' || needs.check_pr_labels.outputs.skip_build != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Currently, the build workflow will be skipped if it happened from a PR merged that was labeled with "documentation". The commit 1cb3be285c6c811c7414ecded0fd84e9ba410ccb fixed an issue where documentation labels broke the build workflow, but ended up making auto skip documentation changes completely.

This led to the changelog and release notes not being updated.

This change should make sure _only_ the build workflow skips when a PR is labeled "documentation"