### PR TITLE
set version in go.mod to be correct format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OpenLabsHQ/CLI
 
-go 1.24.1
+go 1.24
 
 require (
 	github.com/olekukonko/tablewriter v0.0.5


### PR DESCRIPTION
This change ensures tools that pull version from the go.mod file (like linters) can work properly.
